### PR TITLE
Reworking instanceof checks

### DIFF
--- a/dist/uki.esm.js
+++ b/dist/uki.esm.js
@@ -24,20 +24,27 @@ const createMixinAndDefault = function ({
     }
     // Add a hidden property to the mixed class so we can handle instanceof
     // checks properly
-    MixedClass.prototype[`_instanceOf${MixedClass.name}`] = true;
+    MixedClass.prototype._ukiMixinInheritance = (SuperClass.prototype._ukiMixinInheritance || []).concat([MixedClass.name]);
     return MixedClass;
   };
   // Default class definition inherits directly from DefaultSuperClass
   const DefaultClass = Mixin(DefaultSuperClass);
-  // Make the Mixin function behave like a class for instanceof Mixin checks
+  // Make the Mixin function behave like a class for instanceof Mixin checks;
+  // the tested object should start with the same class inheritance order
   Object.defineProperty(Mixin, Symbol.hasInstance, {
-    value: i => !!i?.[`_instanceOf${DefaultClass.name}`]
+    value: i => DefaultClass.prototype._ukiMixinInheritance.every((className, index) => {
+      return className === i?._ukiMixinInheritance?.[index];
+    })
   });
   if (mixedInstanceOfDefault) {
-    // Make instanceof DefaultClass true for anything that technically is only
-    // an instanceof Mixin
+    // Make instanceof DefaultClass true for anything that technically only
+    // shares the same inheritance pattern (i.e. this is softer than strict
+    // javascript inheritance, and allows for something that's only descended
+    // from Mixin to still pass the instanceof DefaultClass check)
     Object.defineProperty(DefaultClass, Symbol.hasInstance, {
-      value: i => !!i?.[`_instanceOf${DefaultClass.name}`]
+      value: i => DefaultClass.prototype._ukiMixinInheritance.every((className, index) => {
+        return className === i?._ukiMixinInheritance?.[index];
+      })
     });
   }
   // Return both the default class and the mixin function
@@ -940,7 +947,7 @@ const { View, ViewMixin } = createMixinAndDefault({
 });
 
 var name = "uki";
-var version = "0.7.8";
+var version = "0.7.9";
 var description = "Minimal, d3-based Model-View library";
 var module = "dist/uki.esm.js";
 var scripts = {

--- a/examples/basic/uki.esm.js
+++ b/examples/basic/uki.esm.js
@@ -24,20 +24,27 @@ const createMixinAndDefault = function ({
     }
     // Add a hidden property to the mixed class so we can handle instanceof
     // checks properly
-    MixedClass.prototype[`_instanceOf${MixedClass.name}`] = true;
+    MixedClass.prototype._ukiMixinInheritance = (SuperClass.prototype._ukiMixinInheritance || []).concat([MixedClass.name]);
     return MixedClass;
   };
   // Default class definition inherits directly from DefaultSuperClass
   const DefaultClass = Mixin(DefaultSuperClass);
-  // Make the Mixin function behave like a class for instanceof Mixin checks
+  // Make the Mixin function behave like a class for instanceof Mixin checks;
+  // the tested object should start with the same class inheritance order
   Object.defineProperty(Mixin, Symbol.hasInstance, {
-    value: i => !!i?.[`_instanceOf${DefaultClass.name}`]
+    value: i => DefaultClass.prototype._ukiMixinInheritance.every((className, index) => {
+      return className === i?._ukiMixinInheritance?.[index];
+    })
   });
   if (mixedInstanceOfDefault) {
-    // Make instanceof DefaultClass true for anything that technically is only
-    // an instanceof Mixin
+    // Make instanceof DefaultClass true for anything that technically only
+    // shares the same inheritance pattern (i.e. this is softer than strict
+    // javascript inheritance, and allows for something that's only descended
+    // from Mixin to still pass the instanceof DefaultClass check)
     Object.defineProperty(DefaultClass, Symbol.hasInstance, {
-      value: i => !!i?.[`_instanceOf${DefaultClass.name}`]
+      value: i => DefaultClass.prototype._ukiMixinInheritance.every((className, index) => {
+        return className === i?._ukiMixinInheritance?.[index];
+      })
     });
   }
   // Return both the default class and the mixin function
@@ -940,7 +947,7 @@ const { View, ViewMixin } = createMixinAndDefault({
 });
 
 var name = "uki";
-var version = "0.7.8";
+var version = "0.7.9";
 var description = "Minimal, d3-based Model-View library";
 var module = "dist/uki.esm.js";
 var scripts = {

--- a/examples/miserables/uki.esm.js
+++ b/examples/miserables/uki.esm.js
@@ -24,20 +24,27 @@ const createMixinAndDefault = function ({
     }
     // Add a hidden property to the mixed class so we can handle instanceof
     // checks properly
-    MixedClass.prototype[`_instanceOf${MixedClass.name}`] = true;
+    MixedClass.prototype._ukiMixinInheritance = (SuperClass.prototype._ukiMixinInheritance || []).concat([MixedClass.name]);
     return MixedClass;
   };
   // Default class definition inherits directly from DefaultSuperClass
   const DefaultClass = Mixin(DefaultSuperClass);
-  // Make the Mixin function behave like a class for instanceof Mixin checks
+  // Make the Mixin function behave like a class for instanceof Mixin checks;
+  // the tested object should start with the same class inheritance order
   Object.defineProperty(Mixin, Symbol.hasInstance, {
-    value: i => !!i?.[`_instanceOf${DefaultClass.name}`]
+    value: i => DefaultClass.prototype._ukiMixinInheritance.every((className, index) => {
+      return className === i?._ukiMixinInheritance?.[index];
+    })
   });
   if (mixedInstanceOfDefault) {
-    // Make instanceof DefaultClass true for anything that technically is only
-    // an instanceof Mixin
+    // Make instanceof DefaultClass true for anything that technically only
+    // shares the same inheritance pattern (i.e. this is softer than strict
+    // javascript inheritance, and allows for something that's only descended
+    // from Mixin to still pass the instanceof DefaultClass check)
     Object.defineProperty(DefaultClass, Symbol.hasInstance, {
-      value: i => !!i?.[`_instanceOf${DefaultClass.name}`]
+      value: i => DefaultClass.prototype._ukiMixinInheritance.every((className, index) => {
+        return className === i?._ukiMixinInheritance?.[index];
+      })
     });
   }
   // Return both the default class and the mixin function
@@ -940,7 +947,7 @@ const { View, ViewMixin } = createMixinAndDefault({
 });
 
 var name = "uki";
-var version = "0.7.8";
+var version = "0.7.9";
 var description = "Minimal, d3-based Model-View library";
 var module = "dist/uki.esm.js";
 var scripts = {

--- a/examples/resources/uki.esm.js
+++ b/examples/resources/uki.esm.js
@@ -24,20 +24,27 @@ const createMixinAndDefault = function ({
     }
     // Add a hidden property to the mixed class so we can handle instanceof
     // checks properly
-    MixedClass.prototype[`_instanceOf${MixedClass.name}`] = true;
+    MixedClass.prototype._ukiMixinInheritance = (SuperClass.prototype._ukiMixinInheritance || []).concat([MixedClass.name]);
     return MixedClass;
   };
   // Default class definition inherits directly from DefaultSuperClass
   const DefaultClass = Mixin(DefaultSuperClass);
-  // Make the Mixin function behave like a class for instanceof Mixin checks
+  // Make the Mixin function behave like a class for instanceof Mixin checks;
+  // the tested object should start with the same class inheritance order
   Object.defineProperty(Mixin, Symbol.hasInstance, {
-    value: i => !!i?.[`_instanceOf${DefaultClass.name}`]
+    value: i => DefaultClass.prototype._ukiMixinInheritance.every((className, index) => {
+      return className === i?._ukiMixinInheritance?.[index];
+    })
   });
   if (mixedInstanceOfDefault) {
-    // Make instanceof DefaultClass true for anything that technically is only
-    // an instanceof Mixin
+    // Make instanceof DefaultClass true for anything that technically only
+    // shares the same inheritance pattern (i.e. this is softer than strict
+    // javascript inheritance, and allows for something that's only descended
+    // from Mixin to still pass the instanceof DefaultClass check)
     Object.defineProperty(DefaultClass, Symbol.hasInstance, {
-      value: i => !!i?.[`_instanceOf${DefaultClass.name}`]
+      value: i => DefaultClass.prototype._ukiMixinInheritance.every((className, index) => {
+        return className === i?._ukiMixinInheritance?.[index];
+      })
     });
   }
   // Return both the default class and the mixin function
@@ -940,7 +947,7 @@ const { View, ViewMixin } = createMixinAndDefault({
 });
 
 var name = "uki";
-var version = "0.7.8";
+var version = "0.7.9";
 var description = "Minimal, d3-based Model-View library";
 var module = "dist/uki.esm.js";
 var scripts = {

--- a/examples/sandbox/uki.esm.js
+++ b/examples/sandbox/uki.esm.js
@@ -24,20 +24,27 @@ const createMixinAndDefault = function ({
     }
     // Add a hidden property to the mixed class so we can handle instanceof
     // checks properly
-    MixedClass.prototype[`_instanceOf${MixedClass.name}`] = true;
+    MixedClass.prototype._ukiMixinInheritance = (SuperClass.prototype._ukiMixinInheritance || []).concat([MixedClass.name]);
     return MixedClass;
   };
   // Default class definition inherits directly from DefaultSuperClass
   const DefaultClass = Mixin(DefaultSuperClass);
-  // Make the Mixin function behave like a class for instanceof Mixin checks
+  // Make the Mixin function behave like a class for instanceof Mixin checks;
+  // the tested object should start with the same class inheritance order
   Object.defineProperty(Mixin, Symbol.hasInstance, {
-    value: i => !!i?.[`_instanceOf${DefaultClass.name}`]
+    value: i => DefaultClass.prototype._ukiMixinInheritance.every((className, index) => {
+      return className === i?._ukiMixinInheritance?.[index];
+    })
   });
   if (mixedInstanceOfDefault) {
-    // Make instanceof DefaultClass true for anything that technically is only
-    // an instanceof Mixin
+    // Make instanceof DefaultClass true for anything that technically only
+    // shares the same inheritance pattern (i.e. this is softer than strict
+    // javascript inheritance, and allows for something that's only descended
+    // from Mixin to still pass the instanceof DefaultClass check)
     Object.defineProperty(DefaultClass, Symbol.hasInstance, {
-      value: i => !!i?.[`_instanceOf${DefaultClass.name}`]
+      value: i => DefaultClass.prototype._ukiMixinInheritance.every((className, index) => {
+        return className === i?._ukiMixinInheritance?.[index];
+      })
     });
   }
   // Return both the default class and the mixin function
@@ -940,7 +947,7 @@ const { View, ViewMixin } = createMixinAndDefault({
 });
 
 var name = "uki";
-var version = "0.7.8";
+var version = "0.7.9";
 var description = "Minimal, d3-based Model-View library";
 var module = "dist/uki.esm.js";
 var scripts = {

--- a/examples/twoViewsOneElement/uki.esm.js
+++ b/examples/twoViewsOneElement/uki.esm.js
@@ -24,20 +24,27 @@ const createMixinAndDefault = function ({
     }
     // Add a hidden property to the mixed class so we can handle instanceof
     // checks properly
-    MixedClass.prototype[`_instanceOf${MixedClass.name}`] = true;
+    MixedClass.prototype._ukiMixinInheritance = (SuperClass.prototype._ukiMixinInheritance || []).concat([MixedClass.name]);
     return MixedClass;
   };
   // Default class definition inherits directly from DefaultSuperClass
   const DefaultClass = Mixin(DefaultSuperClass);
-  // Make the Mixin function behave like a class for instanceof Mixin checks
+  // Make the Mixin function behave like a class for instanceof Mixin checks;
+  // the tested object should start with the same class inheritance order
   Object.defineProperty(Mixin, Symbol.hasInstance, {
-    value: i => !!i?.[`_instanceOf${DefaultClass.name}`]
+    value: i => DefaultClass.prototype._ukiMixinInheritance.every((className, index) => {
+      return className === i?._ukiMixinInheritance?.[index];
+    })
   });
   if (mixedInstanceOfDefault) {
-    // Make instanceof DefaultClass true for anything that technically is only
-    // an instanceof Mixin
+    // Make instanceof DefaultClass true for anything that technically only
+    // shares the same inheritance pattern (i.e. this is softer than strict
+    // javascript inheritance, and allows for something that's only descended
+    // from Mixin to still pass the instanceof DefaultClass check)
     Object.defineProperty(DefaultClass, Symbol.hasInstance, {
-      value: i => !!i?.[`_instanceOf${DefaultClass.name}`]
+      value: i => DefaultClass.prototype._ukiMixinInheritance.every((className, index) => {
+        return className === i?._ukiMixinInheritance?.[index];
+      })
     });
   }
   // Return both the default class and the mixin function
@@ -940,7 +947,7 @@ const { View, ViewMixin } = createMixinAndDefault({
 });
 
 var name = "uki";
-var version = "0.7.8";
+var version = "0.7.9";
 var description = "Minimal, d3-based Model-View library";
 var module = "dist/uki.esm.js";
 var scripts = {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uki",
-  "version": "0.7.8",
+  "version": "0.7.9",
   "description": "Minimal, d3-based Model-View library",
   "module": "dist/uki.esm.js",
   "jsnext:main": "dist/uki.esm.js",

--- a/src/utils/createMixinAndDefault.js
+++ b/src/utils/createMixinAndDefault.js
@@ -24,20 +24,27 @@ const createMixinAndDefault = function ({
     }
     // Add a hidden property to the mixed class so we can handle instanceof
     // checks properly
-    MixedClass.prototype[`_instanceOf${MixedClass.name}`] = true;
+    MixedClass.prototype._ukiMixinInheritance = (SuperClass.prototype._ukiMixinInheritance || []).concat([MixedClass.name]);
     return MixedClass;
   };
   // Default class definition inherits directly from DefaultSuperClass
   const DefaultClass = Mixin(DefaultSuperClass);
-  // Make the Mixin function behave like a class for instanceof Mixin checks
+  // Make the Mixin function behave like a class for instanceof Mixin checks;
+  // the tested object should start with the same class inheritance order
   Object.defineProperty(Mixin, Symbol.hasInstance, {
-    value: i => !!i?.[`_instanceOf${DefaultClass.name}`]
+    value: i => DefaultClass.prototype._ukiMixinInheritance.every((className, index) => {
+      return className === i?._ukiMixinInheritance?.[index];
+    })
   });
   if (mixedInstanceOfDefault) {
-    // Make instanceof DefaultClass true for anything that technically is only
-    // an instanceof Mixin
+    // Make instanceof DefaultClass true for anything that technically only
+    // shares the same inheritance pattern (i.e. this is softer than strict
+    // javascript inheritance, and allows for something that's only descended
+    // from Mixin to still pass the instanceof DefaultClass check)
     Object.defineProperty(DefaultClass, Symbol.hasInstance, {
-      value: i => !!i?.[`_instanceOf${DefaultClass.name}`]
+      value: i => DefaultClass.prototype._ukiMixinInheritance.every((className, index) => {
+        return className === i?._ukiMixinInheritance?.[index];
+      })
     });
   }
   // Return both the default class and the mixin function


### PR DESCRIPTION
I *think* I need to change `instanceof` to verify that Mixins are applied in the same order—currently, `instanceof` checks give a false positive when two very different classes share a common base default class

(this is a big change, probably a sign I need to finally get around to adding a test suite)